### PR TITLE
Compatibility with current download file format of HaveIBeenPawnd

### DIFF
--- a/CheckPwnedPasswords.csproj
+++ b/CheckPwnedPasswords.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/CheckPwnedPasswords.sln
+++ b/CheckPwnedPasswords.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34316.72
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CheckPwnedPasswords", "CheckPwnedPasswords.csproj", "{5DBD582E-F177-4721-ACD4-235489D14580}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5DBD582E-F177-4721-ACD4-235489D14580}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5DBD582E-F177-4721-ACD4-235489D14580}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5DBD582E-F177-4721-ACD4-235489D14580}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5DBD582E-F177-4721-ACD4-235489D14580}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {6F6A3A22-C36F-4777-84AA-94FD1828CF83}
+	EndGlobalSection
+EndGlobal

--- a/Program.cs
+++ b/Program.cs
@@ -147,8 +147,6 @@ namespace CheckPwnedPasswords
             long high = sr.Length;
             long low = 0L;
 
-            int ch;
-
             while (low <= high)
             {
                 long middle = (low + high + 1) / 2;
@@ -162,16 +160,20 @@ namespace CheckPwnedPasswords
 				{
 					middle -= 1;
 					sr.Seek(middle, SeekOrigin.Begin);
-					ch = sr.ReadByte();
-					if (ch == 0x0d)
-					{
-						ch = sr.ReadByte();
-						if (ch == 0x0a && middle < sr.Length - 1)
-						{
-							middle += 2;
-							do_seek = false;
-						}
-					}
+					int ch1 = sr.ReadByte();
+                    int ch2 = sr.ReadByte();
+                    if (ch1 == 0x0d && ch2 == 0x0a)
+                    {
+                        //Windows NL(0d0a) and file position is on 0x0d
+                        middle += 2;
+                        do_seek = false;
+                    }
+                    if (ch1 == 0x0a)
+                    {
+                        //Windows NL(0d0a) or Posix NL(0a) and file position is on 0x0a
+                        middle += 1;
+                        do_seek = false;
+                    }
 				}
 				sr.Seek(middle, SeekOrigin.Begin);
 

--- a/Program.cs
+++ b/Program.cs
@@ -8,43 +8,103 @@ namespace CheckPwnedPasswords
 {
     class Program
     {
+        //Length of the SHA1 hash
+        const int SHA1LENGTH = 40;
+
         static void Main(string[] args)
 		{
 			List<string> filesToSearch = ProcessArguments(args);
 
-			while (true)
+            static string ByteArrayToString(byte[] ba)
+            {
+                string hex = BitConverter.ToString(ba);
+                return hex.Replace("-", "");
+            }
+
+            byte[] bytes;
+            System.Security.Cryptography.SHA1 sha;
+            byte[] passwordBytes;
+            string asHex;
+
+            while (true)
 			{
-				Console.WriteLine("");
+				//Console.WriteLine("");
 				Console.WriteLine("");
 				Console.WriteLine("Enter password (leave empty to quit):");
-				var pwd = Console.ReadLine();
-				if (string.IsNullOrWhiteSpace(pwd)) return;
 
-				foreach (var file in filesToSearch)
+                //var pwd = Console.ReadLine();
+                var pwd = string.Empty;
+                ConsoleKey key;
+                do
+                {
+                    var keyInfo = Console.ReadKey(intercept: true);
+                    key = keyInfo.Key;
+
+                    if (key == ConsoleKey.Backspace && pwd.Length > 0)
+                    {
+                        Console.Write("\b \b");
+                        pwd = pwd[0..^1];
+                    }
+                    else if (!char.IsControl(keyInfo.KeyChar))
+                    {
+                        Console.Write("*");
+                        pwd += keyInfo.KeyChar;
+                    }
+                } while (key != ConsoleKey.Enter);
+                Console.Write("\n");
+
+                if (string.IsNullOrWhiteSpace(pwd)) return;
+
+                bytes = System.Text.Encoding.UTF8.GetBytes(pwd);
+                sha = System.Security.Cryptography.SHA1.Create();
+                passwordBytes = sha.ComputeHash(bytes);
+                asHex = ByteArrayToString(passwordBytes);
+                Console.WriteLine($"Password SHA1 hash is: {asHex}");
+
+                foreach (var file in filesToSearch)
 				{
 					var sw = new Stopwatch();
 					sw.Start();
-					var result = Check(pwd, file);
+					var result = Check(asHex, file);
 					sw.Stop();
-
 
 					if (result)
 					{
-						Console.WriteLine($"{pwd} is in {file} - time taken was {sw.Elapsed.Milliseconds}ms");
+                        Console.WriteLine($"Found in {file} - time taken was {sw.Elapsed.Milliseconds}ms");
 						break;
 					}
 					else
 					{
-						Console.WriteLine($"{pwd} is NOT in {file} - time taken was {sw.Elapsed.Milliseconds}ms");
+						Console.WriteLine($"NOT found in {file} - time taken was {sw.Elapsed.Milliseconds}ms");
 					}
-				}
+
+                    if(pwd.Length == SHA1LENGTH)
+                    {
+                        //pwd is perhaps already a SHA1 hash so check it too
+                        Console.WriteLine($"Looking for password as it looks like a SHA hash itself ({SHA1LENGTH} bytes long)");
+
+                        sw.Reset();
+                        sw.Start();
+                        result = Check(pwd, file);
+                        sw.Stop();
+                        if (result)
+                        {
+                            Console.WriteLine($"Found hash in {file} - time taken was {sw.Elapsed.Milliseconds}ms");
+                            break;
+                        }
+                        else
+                        {
+                            Console.WriteLine($"Hash NOT found in {file} - time taken was {sw.Elapsed.Milliseconds}ms");
+                        }
+                    }
+                }
 			}
 		}
 
 		private static List<string> ProcessArguments(string[] args)
 		{
-			List<string> filesToSearch = new List<string>();
-			List<string> directoriesToSearch = new List<string>();
+			List<string> filesToSearch = [];
+			List<string> directoriesToSearch = [];
 
 			string baseDataDir = Path.Combine(AppContext.BaseDirectory, "data");
 			if (Directory.Exists(baseDataDir))
@@ -76,58 +136,66 @@ namespace CheckPwnedPasswords
 			return filesToSearch;
 		}
 
-		static bool Check(string password, string filename)
+		static bool Check(string asHex, string filename)
         {
-            string ByteArrayToString(byte[] ba)
+            var buffer = new byte[SHA1LENGTH];
+            using var sr = File.OpenRead(filename);
+            
+            //Number of lines
+            //var high = (sr.Length / (LINELENGTH + 2)) - 1;
+            //As line length is now variable just use the bytes in the file:
+            long high = sr.Length;
+            long low = 0L;
+
+            int ch;
+
+            while (low <= high)
             {
-                string hex = BitConverter.ToString(ba);
-                return hex.Replace("-", "");
-            }
+                long middle = (low + high + 1) / 2;
+                //Console.WriteLine($"{low}:{middle}:{high}");
+                
+                //sr.Seek((LINELENGTH + 2) * ((long)middle), SeekOrigin.Begin);
 
-            var bytes = System.Text.Encoding.UTF8.GetBytes(password);
-            var sha = System.Security.Cryptography.SHA1.Create();
-            var passwordBytes = sha.ComputeHash(bytes);
-            var asHex = ByteArrayToString(passwordBytes);
+				//seek to next cr/newline (0d0a) ahead of current position
+                bool do_seek = true;
+				while (middle >= low+1 && do_seek)
+				{
+					middle -= 1;
+					sr.Seek(middle, SeekOrigin.Begin);
+					ch = sr.ReadByte();
+					if (ch == 0x0d)
+					{
+						ch = sr.ReadByte();
+						if (ch == 0x0a && middle < sr.Length - 1)
+						{
+							middle += 2;
+							do_seek = false;
+						}
+					}
+				}
+				sr.Seek(middle, SeekOrigin.Begin);
 
-            //Length of the SHA1 hash  (we use LINELENGTH+2 is take the newline characters into account)
-            const int LINELENGTH = 40;
+                sr.Read(buffer, 0, SHA1LENGTH);
+                var readLine = Encoding.ASCII.GetString(buffer);
 
-            var buffer = new byte[LINELENGTH];
-            using (var sr = File.OpenRead(filename))
-            {
-                //Number of lines
-                var high = (sr.Length / (LINELENGTH + 2)) - 1;
-                var low = 0L;
-
-                while (low <= high)
+                switch (readLine.CompareTo(asHex))
                 {
-                    var middle = (low + high + 1) / 2;
-                    sr.Seek((LINELENGTH + 2) * ((long)middle), SeekOrigin.Begin);
-                    sr.Read(buffer, 0, LINELENGTH);
-                    var readLine = Encoding.ASCII.GetString(buffer);
+                    case 0:
+                        return true;
 
-                    switch (readLine.CompareTo(asHex))
-                    {
-                        case 0:
-                            return true;
+                    case 1:
+                        high = middle - 1;
+                        break;
 
-                        case 1:
-                            high = middle - 1;
-                            break;
+                    case -1:
+                        low = middle + 1;
+                        break;
 
-                        case -1:
-                            low = middle + 1;
-                            break;
-
-                        default:
-                            break;
-                    }
+                    default:
+                        break;
                 }
-
             }
-
             return false;
-
         }
     }
 }


### PR DESCRIPTION
- build target now .net8.0
- Changes for current pwnedpasswords.txt format where lines have variable length because after each hash the count of occurences has been added, delimiter is ":".
- Password input does not echo  the password anymore => passwords are never visible, length of password still visible
- If password itself is a SHA1 hash (check if it is 40 bytes long), additional search for password
- Some minor changes in text output

- minor changes to get rid of warnings about code style